### PR TITLE
Support 0.14.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Marble is a [metamorphic testing](https://en.wikipedia.org/wiki/Metamorphic_testing) library for Zig.
 
-This library tracks Zig master and was last tested on `0.12.0-dev.4472+1c7798a3c`
+This library tracks Zig master and was last tested on `0.14.0-dev.3187+d4c85079c`
 
 Metamorphic testing is a powerful technique that provides additional test coverage by applying a number of transformations to test input, and then checking if certain relations still hold between the outputs. Marble will automatically run through all possible combinations of these transformations.
 

--- a/src/example_tests.zig
+++ b/src/example_tests.zig
@@ -105,9 +105,8 @@ test "query" {
 /// MT relations courtesy of @jacobdweightman
 const BinarySearchTest = struct {
     const S = struct {
-        fn order(context: void, lhs: usize, rhs: usize) std.math.Order {
-            _ = context;
-            return std.math.order(lhs, rhs);
+        fn order(context: usize, rhs: usize) std.math.Order {
+            return std.math.order(context, rhs);
         }
     };
 
@@ -126,7 +125,7 @@ const BinarySearchTest = struct {
     ///   if x = A[k], then binarySearch(x, A) = k
     pub fn transformSimple(self: *BinarySearchTest) void {
         const x = self.arr[self.value.?];
-        self.value = std.sort.binarySearch(usize, x, self.arr, {}, S.order);
+        self.value = std.sort.binarySearch(usize, self.arr, x, S.order);
     }
 
     // This transform will catch an error where the value being searched for is
@@ -138,14 +137,14 @@ const BinarySearchTest = struct {
         var x = self.arr[self.value.? - 1] + 1;
         if (x == self.arr[self.value.?]) x += 1;
         if (x >= self.arr[self.value.? + 1]) return;
-        self.value = std.sort.binarySearch(usize, x, self.arr, {}, S.order);
+        self.value = std.sort.binarySearch(usize, self.arr, x, S.order);
     }
 
     /// Test binary search array splitting correctness:
     //    if x = A[k], then binarySearch(A[k-1], A) = k-1 and binarySearch(A[k+1], A) = k + 1
     pub fn transformSplitting(self: *BinarySearchTest) void {
         const x = self.arr[self.value.?];
-        self.value = std.sort.binarySearch(usize, x, self.arr, {}, S.order);
+        self.value = std.sort.binarySearch(usize, self.arr, x, S.order);
     }
 
     pub fn check(self: *BinarySearchTest, org: ?usize, new: ?usize) bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,7 +66,7 @@ fn Transformer(comptime TestType: type) type {
 /// starts with "transform". Combinations of these functions will be executed
 /// during test runs.
 fn findTransformers(comptime T: type) []const Transformer(T) {
-    const functions = @typeInfo(T).Struct.decls;
+    const functions = @typeInfo(T).@"struct".decls;
     var transformers: []const Transformer(T) = &[_]Transformer(T){};
     inline for (functions) |f| {
         if (std.mem.startsWith(u8, f.name, "transform")) {


### PR DESCRIPTION
There were a couple of API changes in 0.14 that caused this to not build.  I have fixes here.

I don't think there's a way to make it forward and backwards compatible.  I mostly just see people have compiler-specific branches.